### PR TITLE
feat: 관리자 공지사항 목록, 조회, 삭제, 등록, 수정 기능 구현

### DIFF
--- a/src/main/java/com/universestay/project/notice/controller/NoticeController.java
+++ b/src/main/java/com/universestay/project/notice/controller/NoticeController.java
@@ -1,0 +1,59 @@
+package com.universestay.project.notice.controller;
+
+import com.universestay.project.notice.dto.NoticeDto;
+import com.universestay.project.notice.service.NoticeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequestMapping("/notice")
+public class NoticeController {
+
+    @Autowired
+    NoticeService noticeService;
+
+    @GetMapping("/list")
+    public String list(Model model) throws Exception {
+        model.addAttribute("list", noticeService.getList());
+        return "noticeList";
+    }
+
+    @GetMapping("/read")
+    public String read(@RequestParam("notice_id") Integer notice_id, Model model) throws Exception {
+        model.addAttribute("noticeDto", noticeService.read(notice_id));
+        return "notice";
+    }
+
+    @PostMapping("/remove")
+    public String remove(Integer notice_id, RedirectAttributes rttr) throws Exception {
+        if (noticeService.remove(notice_id) == 1) {
+            rttr.addFlashAttribute("result", "삭제 성공!!!");
+        }
+        return "redirect:/notice/noticeList";
+    }
+
+    @GetMapping("/write")
+    public String getWrite() throws Exception {
+        return "noticeWrite";
+    }
+
+    @PostMapping("/write")
+    public String postWrite(NoticeDto noticeDto) throws Exception {
+        noticeService.write(noticeDto);
+        return "redirect:/notice/noticeList";
+    }
+
+    @PostMapping("/modify")
+    public String modify(NoticeDto noticeDto, RedirectAttributes rttr) throws Exception {
+        if (noticeService.modify(noticeDto) == 1) {
+            rttr.addFlashAttribute("result", "수정 성공!!!");
+        }
+        return "redirect:/notice/noticeList";
+    }
+}

--- a/src/main/java/com/universestay/project/notice/dao/NoticeDao.java
+++ b/src/main/java/com/universestay/project/notice/dao/NoticeDao.java
@@ -1,0 +1,19 @@
+package com.universestay.project.notice.dao;
+
+import com.universestay.project.notice.dto.NoticeDto;
+import java.util.List;
+
+public interface NoticeDao {
+
+    List<NoticeDto> selectAll() throws Exception;
+
+    NoticeDto select(Integer notice_id) throws Exception;
+
+    int delete(Integer notice_id) throws Exception;
+
+    int insert(NoticeDto noticeDto) throws Exception;
+
+    int update(NoticeDto noticeDto) throws Exception;
+
+
+}

--- a/src/main/java/com/universestay/project/notice/dao/NoticeDaoImpl.java
+++ b/src/main/java/com/universestay/project/notice/dao/NoticeDaoImpl.java
@@ -1,0 +1,43 @@
+package com.universestay.project.notice.dao;
+
+import com.universestay.project.notice.dto.NoticeDto;
+import java.util.List;
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class NoticeDaoImpl implements NoticeDao {
+
+    @Autowired
+    private SqlSession session;
+
+    private static String namespace = "com.universestay.project.notice.dao.NoticeDao.";
+
+    @Override
+    public List<NoticeDto> selectAll() throws Exception {
+        return session.selectList(namespace + "selectAll");
+    }
+
+    @Override
+    public NoticeDto select(Integer notice_id) throws Exception {
+        return session.selectOne(namespace + "select", notice_id);
+    }
+
+    @Override
+    public int delete(Integer notice_id) throws Exception {
+        return session.delete(namespace + "delete", notice_id);
+    }
+
+    @Override
+    public int insert(NoticeDto noticeDto) throws Exception {
+        return session.insert(namespace + "insert", noticeDto);
+    }
+
+    @Override
+    public int update(NoticeDto noticeDto) throws Exception {
+        return session.update(namespace + "update", noticeDto);
+    }
+
+
+}

--- a/src/main/java/com/universestay/project/notice/dto/NoticeDto.java
+++ b/src/main/java/com/universestay/project/notice/dto/NoticeDto.java
@@ -1,10 +1,11 @@
-package com.universestay.project.dto;
+package com.universestay.project.notice.dto;
 
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.sql.Timestamp;
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,6 +19,7 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 @ApiModel(description = "Notice DTO")
+@Data
 public class NoticeDto {
 
 

--- a/src/main/java/com/universestay/project/notice/service/NoticeService.java
+++ b/src/main/java/com/universestay/project/notice/service/NoticeService.java
@@ -1,0 +1,18 @@
+package com.universestay.project.notice.service;
+
+import com.universestay.project.notice.dto.NoticeDto;
+import java.util.List;
+
+public interface NoticeService {
+
+    List<NoticeDto> getList() throws Exception;
+
+    NoticeDto read(Integer notice_id) throws Exception;
+
+    int remove(Integer notice_id) throws Exception;
+
+    int write(NoticeDto noticeDto) throws Exception;
+
+    int modify(NoticeDto noticeDto) throws Exception;
+
+}

--- a/src/main/java/com/universestay/project/notice/service/NoticeServiceImpl.java
+++ b/src/main/java/com/universestay/project/notice/service/NoticeServiceImpl.java
@@ -1,0 +1,39 @@
+package com.universestay.project.notice.service;
+
+import com.universestay.project.notice.dao.NoticeDao;
+import com.universestay.project.notice.dto.NoticeDto;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NoticeServiceImpl implements NoticeService {
+
+    @Autowired
+    NoticeDao noticeDao;
+
+    @Override
+    public List<NoticeDto> getList() throws Exception {
+        return noticeDao.selectAll();
+    }
+
+    @Override
+    public NoticeDto read(Integer notice_id) throws Exception {
+        return noticeDao.select(notice_id);
+    }
+
+    @Override
+    public int remove(Integer notice_id) throws Exception {
+        return noticeDao.delete(notice_id);
+    }
+
+    @Override
+    public int write(NoticeDto noticeDto) throws Exception {
+        return noticeDao.insert(noticeDto);
+    }
+
+    @Override
+    public int modify(NoticeDto noticeDto) throws Exception {
+        return noticeDao.update(noticeDto);
+    }
+}

--- a/src/main/resources/mybatis/mapper/notice/noticeMapper.xml
+++ b/src/main/resources/mybatis/mapper/notice/noticeMapper.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.universestay.project.notice.dao.NoticeDao">
+    <select id="selectAll" resultType="com.universestay.project.notice.dto.NoticeDto">
+        select *
+        from Notice
+        order by notice_id DESC
+    </select>
+
+    <select id="select" resultType="com.universestay.project.notice.dto.NoticeDto">
+        select *
+        from Notice
+        where notice_id = #{notice_id}
+    </select>
+
+    <delete id="delete" parameterType="int">
+        delete
+        from Notice
+        where notice_id = #{notice_id}
+    </delete>
+
+    <insert id="insert" parameterType="com.universestay.project.notice.dto.NoticeDto">
+        insert into Notice
+        (admin_id, notice_title, notice_ctt, created_at, created_id, updated_at, updated_id)
+        values (#{admin_id}, #{notice_title}, #{notice_ctt}, now(), #{admin_id}, now(), #{admin_id})
+    </insert>
+
+    <update id="update" parameterType="com.universestay.project.notice.dto.NoticeDto">
+        update Notice
+        set notice_title   = #{notice_title},
+            notice_ctt     = #{notice_ctt},
+            notice_is_open = #{notice_is_open},
+            updated_at     = now(),
+            updated_id     = #{updated_id}
+        where notice_id = #{notice_id}
+    </update>
+</mapper>

--- a/src/main/webapp/WEB-INF/views/notice/notice.jsp
+++ b/src/main/webapp/WEB-INF/views/notice/notice.jsp
@@ -1,0 +1,16 @@
+<%--
+  Created by IntelliJ IDEA.
+  User: sunghoonlee
+  Date: 2023/11/26
+  Time: 22:29
+  To change this template use File | Settings | File Templates.
+--%>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+    <title>noticeGet Page</title>
+</head>
+<body>
+<h1>noticeGet Page 입니다.</h1>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/notice/noticeList.jsp
+++ b/src/main/webapp/WEB-INF/views/notice/noticeList.jsp
@@ -1,0 +1,16 @@
+<%--
+  Created by IntelliJ IDEA.
+  User: sunghoonlee
+  Date: 2023/11/26
+  Time: 22:23
+  To change this template use File | Settings | File Templates.
+--%>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+    <title>noticeList Page</title>
+</head>
+<body>
+<h1>noticeList Page 입니다.</h1>
+</body>
+</html>

--- a/src/test/java/com/universestay/project/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/com/universestay/project/notice/controller/NoticeControllerTest.java
@@ -1,0 +1,88 @@
+package com.universestay.project.notice.controller;
+
+import lombok.extern.log4j.Log4j;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration({
+        "file:src/main/webapp/WEB-INF/spring/root-context.xml",
+        "file:src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml"})
+@Log4j
+public class NoticeControllerTest {
+
+    @Autowired
+    private WebApplicationContext ctx;
+
+    private MockMvc mockMvc;
+
+    @Before
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(ctx).build();
+    }
+
+    @Test
+    public void testList() throws Exception {
+        System.out.println(
+                mockMvc.perform(MockMvcRequestBuilders.get("/notice/list"))
+                        .andReturn()
+                        .getModelAndView()
+                        .getModelMap());
+    }
+
+    @Test
+    public void testRead() throws Exception {
+        System.out.println(mockMvc.perform(MockMvcRequestBuilders.get("/notice/read")
+                        .param("notice_id", "2"))
+                .andReturn()
+                .getModelAndView().getModelMap());
+    }
+
+    @Test
+    public void testRemove() throws Exception {
+        // 삭제 전 데이터베이스에 공지사항 번호 확인할 것!
+        String resultPage = mockMvc.perform(MockMvcRequestBuilders.post("/notice/remove")
+                .param("notice_id", "4")
+        ).andReturn().getModelAndView().getViewName();
+        System.out.println(resultPage);
+    }
+
+    @Test
+    public void testWrite() throws Exception {
+        String resultPage = mockMvc.perform(MockMvcRequestBuilders.post("/notice/write")
+                .param("admin_id", "8028bee4-6025-4c58-8c7f-839d7dc0d45t")
+                .param("notice_title", "2023/11/27 월요일 공지사항")
+                .param("notice_ctt",
+                        "universeStay를 이용하시는 고객 여러분 감사드립니다! 조금 더 안정적인 서비스 제공을 위하여 2023/11/30 목요일 23:50 ~ 24:00 까지 점검이 있을 예정입니다.")
+                .param("created_id", "8028bee4-6025-4c58-8c7f-839d7dc0d45t")
+                .param("updated_id", "8028bee4-6025-4c58-8c7f-839d7dc0d45t")
+        ).andReturn().getModelAndView().getViewName();
+
+        System.out.println("RESULT PAGE : " + resultPage);
+    }
+
+    @Test
+    public void testModify() throws Exception {
+        String resultPage = mockMvc
+                .perform(MockMvcRequestBuilders.post("/notice/modify")
+                        .param("notice_id", "23")
+                        .param("notice_title", "변경된 2023/11/27 공지사항")
+                        .param("notice_ctt",
+                                "변경된 universeStay를 이용하시는 고객 여러분 감사드립니다! 조금 더 안정적인 서비스 제공을 위하여 2023/11/23 목요일 23:50 ~ 24:00 까지 점검이 있을 예정입니다.")
+                        .param("notice_is_open", "Y")
+                        .param("updated_id", "8028bee4-6025-4c58-8c7f-839d7dc0d45t")
+                ).andReturn().getModelAndView().getViewName();
+        System.out.println(resultPage);
+    }
+
+}

--- a/src/test/java/com/universestay/project/notice/dao/NoticeDaoImplTest.java
+++ b/src/test/java/com/universestay/project/notice/dao/NoticeDaoImplTest.java
@@ -1,0 +1,57 @@
+package com.universestay.project.notice.dao;
+
+import com.universestay.project.notice.dto.NoticeDto;
+import lombok.extern.log4j.Log4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("file:src/main/webapp/WEB-INF/spring/root-context.xml")
+@Log4j
+public class NoticeDaoImplTest {
+
+    @Autowired
+    NoticeDao noticeDao;
+
+    @Test
+    public void selectAll() throws Exception {
+        System.out.println(noticeDao.selectAll());
+    }
+
+    @Test
+    public void select() throws Exception {
+        System.out.println(noticeDao.select(14));
+    }
+
+    @Test
+    public void delete() throws Exception {
+        System.out.println("@@@@@@@DELETE COUNT = " + noticeDao.delete(14));
+    }
+
+    @Test
+    public void insert() throws Exception {
+        NoticeDto noticeDto = new NoticeDto();
+        noticeDto.setAdmin_id("0ca24692-89ea-11ee-b9d1-0242ac120002");
+        noticeDto.setNotice_title("2023/11/25 토요일 - 서버 점검이 있습니다.");
+        noticeDto.setNotice_ctt(
+                "universeStay를 이용하시는 고객 여러분 감사드립니다! 조금 더 안정적인 서비스 제공을 위하여 2023/11/23 목요일 23:50 ~ 24:00 까지 점검이 있을 예정입니다.");
+        noticeDto.setCreated_id("0ca24692-89ea-11ee-b9d1-0242ac120002");
+        noticeDto.setUpdated_id("0ca24692-89ea-11ee-b9d1-0242ac120002");
+        System.out.println("@@@@@@@INSERT COUNT = " + noticeDao.insert(noticeDto));
+    }
+
+    @Test
+    public void update() throws Exception {
+        NoticeDto noticeDto = new NoticeDto();
+        noticeDto.setNotice_id(18);
+        noticeDto.setNotice_title("변경된 제목!!!");
+        noticeDto.setNotice_ctt("변경된 내용!!!");
+        noticeDto.setNotice_is_open("Y");
+        noticeDto.setUpdated_id("8028bee4-6025-4c58-8c7f-839d7dc0d45t");
+        System.out.println("@@@@@@UPDATE COUNT = " + noticeDao.update(noticeDto));
+    }
+
+}

--- a/src/test/java/com/universestay/project/notice/service/NoticeServiceImplTest.java
+++ b/src/test/java/com/universestay/project/notice/service/NoticeServiceImplTest.java
@@ -1,0 +1,57 @@
+package com.universestay.project.notice.service;
+
+import com.universestay.project.notice.dto.NoticeDto;
+import lombok.extern.log4j.Log4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("file:src/main/webapp/WEB-INF/spring/root-context.xml")
+@Log4j
+public class NoticeServiceImplTest {
+
+    @Autowired
+    NoticeService noticeService;
+
+    @Test
+    public void getList() throws Exception {
+        System.out.println(noticeService.getList());
+    }
+
+    @Test
+    public void read() throws Exception {
+        System.out.println(noticeService.read(18));
+    }
+
+    @Test
+    public void remove() throws Exception {
+        System.out.println(noticeService.remove(18));
+    }
+
+    @Test
+    public void write() throws Exception {
+        NoticeDto noticeDto = new NoticeDto();
+        noticeDto.setAdmin_id("0ca24692-89ea-11ee-b9d1-0242ac120002");
+        noticeDto.setNotice_title("2023/11/25 토요일 - 서버 점검이 있습니다.");
+        noticeDto.setNotice_ctt(
+                "universeStay를 이용하시는 고객 여러분 감사드립니다! 조금 더 안정적인 서비스 제공을 위하여 2023/11/23 목요일 23:50 ~ 24:00 까지 점검이 있을 예정입니다.");
+        noticeDto.setCreated_id("0ca24692-89ea-11ee-b9d1-0242ac120002");
+        noticeDto.setUpdated_id("0ca24692-89ea-11ee-b9d1-0242ac120002");
+        System.out.println("write COUNT = " + noticeService.write(noticeDto));
+    }
+
+    @Test
+    public void modify() throws Exception {
+        NoticeDto noticeDto = new NoticeDto();
+        noticeDto.setNotice_id(19);
+        noticeDto.setNotice_title("변경된 제목!!!");
+        noticeDto.setNotice_ctt("변경된 내용!!!");
+        noticeDto.setNotice_is_open("Y");
+        noticeDto.setUpdated_id("8028bee4-6025-4c58-8c7f-839d7dc0d45t");
+        System.out.println("modify COUNT = " + noticeService.modify(noticeDto));
+    }
+
+}


### PR DESCRIPTION
# feat: task-133

### 개요 (task-133)

- 관리자 공지사항 목록, 조회, 삭제, 등록, 수정 기능 구현(목록 페이징 처리, 검색 기능은 아직 미완입니다.)
- Controller, Service, Dao Test 코드 작성 (DB에서 insert, update, select, delete 잘 작동하는지 테스트)

### 작업 사항

- [x] 작업 사항
  - `notice/controller/NoticeController.java`
  - `notice/dao/NoticeDao.java`
  - `notice/dao/NoticeDaoImpl.java`
  - `notice/service/NoticeService.java`
  - `notice/service/NoticeServiceImpl.java`
  -  `mapper/notice/noticeMapper.xml`
- [x] 테스트 코드 작성
  - `test/notice/controller/NoticeControllerTest.java`
  - `test/notice/dao/NoticeDaoImplTest.java`
  - `test/notice/service/NoticeServiceImplTest.java`