### PR TITLE
hotfix: roomDao 사용하지 않는 메소드 삭제

### DIFF
--- a/src/main/java/com/universestay/project/room/dao/RoomDao.java
+++ b/src/main/java/com/universestay/project/room/dao/RoomDao.java
@@ -22,9 +22,5 @@ public interface RoomDao {
 
     Integer statusHostroom(String room_id, String room_status_id) throws Exception;
 
-    List<Map<String, Object>> selectAllByCategory(String room_category_id) throws Exception;
-
-    List<Map<String, Object>> selectAllByView(String view_status_id) throws Exception;
-
     Integer saveRoomDto(RoomDto roomDto) throws Exception;
 }


### PR DESCRIPTION
# hotfix: roomDao 사용하지 않는 메소드 삭제

### 개요 
- 사용하지 않는 RoomDao 추상메소드 삭제 