### PR TITLE
hotfix: 같은 아이디에 등록한 프로필 이미지 만큼 리뷰를 불러오는 문제로 roomReviewMapper.xml 쿼리문 수정

### DIFF
--- a/src/main/resources/mybatis/mapper/review/roomReviewMapper.xml
+++ b/src/main/resources/mybatis/mapper/review/roomReviewMapper.xml
@@ -11,6 +11,7 @@
                            ON u.user_id = p.user_id
         where rr.room_id = #{room_id}
           and rr.user_id = rr.review_writer
+          and p.profile_img_is_remove = 'N'
         order by created_at desc
     </select>
 
@@ -46,6 +47,7 @@
                            ON u.user_id = p.user_id
         where rr.room_id = #{room_id}
           and rr.user_id = rr.review_writer
+          and p.profile_img_is_remove = 'N'
         order by created_at desc limit 6
     </select>
 </mapper>


### PR DESCRIPTION
# feat: task-481

### 작업 사항

- [x] 작업 사항
    - [hotfix: 같은 아이디에 등록한 프로필 이미지 만큼 리뷰를 불러오는 문제로 roomReviewMapper.xml 쿼리문 수정](https://github.com/GeumZzoks/universeStay/commit/479b02fcebe4a39df0b9d1f9b641341a83e1f3ac)

### 변경후

- 대표사진이 등록된 이미지가 있으면 그 프로필 사진으로 불러와지고 없으면 기본 이미지로 불러와지게 처리했습니다.
